### PR TITLE
Implement basic functionality

### DIFF
--- a/conf/cloudformation/cloudformation.yml
+++ b/conf/cloudformation/cloudformation.yml
@@ -72,6 +72,7 @@ Resources:
                 Variables:
                     APP_ID: !Ref AppId
                     CAPI_KEY: !Ref CapiKey
+                    DYNAMO_ARN: !Ref DynamodbTable
             Code:
                 S3Bucket: !Ref DeployBucket
                 S3Key: !Sub content-api-alexa-podcasts-skill/${Stage}/alexa-podcasts-skill/artifact.zip

--- a/speechAssets/IntentSchema.json
+++ b/speechAssets/IntentSchema.json
@@ -1,0 +1,30 @@
+{
+    "intents": [
+      {
+        "intent":"GetPodcast",
+        "slots": [
+          {
+            "name": "podcast",
+            "type": "PODCAST"
+          }
+        ]
+      },
+      {
+        "intent":"PlayPodcast",
+        "slots": [
+          {
+            "name": "podcast",
+            "type": "PODCAST"
+          }
+        ]
+      },
+      {"intent":"ListPodcasts"},
+      {"intent":"ResumePodcast"},
+      
+      {"intent":"AMAZON.PauseIntent"},
+      {"intent":"AMAZON.ResumeIntent"},
+      {"intent":"AMAZON.YesIntent"},
+      {"intent":"AMAZON.NoIntent"}
+    ]
+}
+

--- a/speechAssets/PODCAST.txt
+++ b/speechAssets/PODCAST.txt
@@ -1,0 +1,17 @@
+Football Weekly
+Politics Weekly
+Close Encounters
+Science Weekly
+Film Weekly
+Premier League: the view from Australia
+The Long Read
+The Story
+Brain waves
+Books podcast
+Music Weekly
+Chips with everything
+Politics for humans
+what would a feminist do
+Behind the lines
+The Citadel
+

--- a/speechAssets/SampleUtterances.txt
+++ b/speechAssets/SampleUtterances.txt
@@ -1,0 +1,11 @@
+GetPodcast get the latest {podcast}
+GetPodcast latest {podcast}
+GetPodcast {podcast}
+
+PlayPodcast play the latest {podcast}
+PlayPodcast play {podcast}
+
+ListPodcasts list podcasts
+
+ResumePodcast resume podcast
+

--- a/src/common/directives.js
+++ b/src/common/directives.js
@@ -1,0 +1,40 @@
+
+var cardImages = {
+  'smallImageUrl': 'https://s3.amazonaws.com/alexa-config/images/alexa-small.png',
+  'largeImageUrl': 'https://s3.amazonaws.com/alexa-config/images/alexa-large.png'
+}
+
+exports.playDirective = function(url, title, offset) {
+  return {
+    'version': '1.0',
+    'sessionAttributes': {},
+    'response': {
+      'card': {
+        'type': 'Standard',
+        'title': 'Playing Podcast',
+        'text': title,
+        'image': cardImages
+      },
+      'reprompt': {
+        'outputSpeech': {
+          'type': 'PlainText',
+          'text': null
+        }
+      },
+      'directives': [
+        {
+          'type': 'AudioPlayer.Play',
+          'playBehavior': 'REPLACE_ALL',
+          'audioItem': {
+            'stream': {
+              'token': JSON.stringify({ url: url, title: title }),
+              'url': url,
+              'offsetInMilliseconds': offset || 0
+            }
+          }
+        }
+      ],
+      'shouldEndSession': true
+    }
+  }
+}

--- a/src/common/getEpisode.js
+++ b/src/common/getEpisode.js
@@ -1,0 +1,65 @@
+var get = require('simple-get-promise').get
+var asJson = require('simple-get-promise').asJson
+
+var BASE_URL = 'https://content.guardianapis.com/'
+
+function getPodcastCapiUrl(podcastName) {
+  switch (podcastName.toLowerCase()) {
+    case 'football':
+    case 'football weekly': return 'football/series/footballweekly'
+
+    case 'politics':
+    case 'politics weekly': return 'politics/series/politicsweekly'
+
+    case 'science':
+    case 'science weekly': return 'science/series/science'
+
+    case 'film':
+    case 'film weekly': return 'film/series/the-dailies-podcast'
+
+    case 'in depth':
+    case 'the long read':
+    case 'long read': return 'news/series/the-audio-long-read'
+
+    case 'books':
+    case 'books podcast': return 'books/series/books'
+
+    default: return null
+  }
+}
+
+function takeUpToHyphen(s) {
+  return s.split(/[-–]/)[0].trim()
+}
+
+exports.getEpisode = function(slots) {
+  return new Promise((resolve, reject) => {
+    if (slots && slots.podcast && slots.podcast.value && getPodcastCapiUrl(slots.podcast.value)) {
+      var capiQuery = BASE_URL
+        + getPodcastCapiUrl(slots.podcast.value)
+        + '?tag=type/podcast&type=audio&show-elements=audio'
+        + '&api-key=' + process.env.CAPI_KEY
+        + '&page-size=1'
+
+      get(capiQuery)
+        .then(asJson)
+        .then(seriesJson => {
+          var item = seriesJson.response.results[0]
+          var result = {
+            podcastTitle: takeUpToHyphen(seriesJson.response.tag.webTitle),
+            episodeUrl: item.elements[0].assets[0].file,
+            episodeTitle: takeUpToHyphen(item.webTitle)
+          }
+
+          return resolve(result)
+        })
+        .catch(function (error) {
+          console.log(`Error getting podcast from capi: ${error}`)
+          return reject(`Sorry, I can't find anything for ${slots.podcast.value}`)
+        })
+    } else {
+      console.log(`Couldn't find podcast in slot: ${slots}`)
+      return reject(`Sorry, I can't find anything for that at the moment`)
+    }
+  })
+}

--- a/src/common/states.js
+++ b/src/common/states.js
@@ -1,0 +1,4 @@
+exports.states = {
+  MAIN: '_MAIN',
+  GOT_PODCAST: '_GOT_PODCAST'
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,98 @@
 'use strict'
 
-const Alexa = require('alexa-sdk')
+var Alexa = require('alexa-sdk')
 
-const APP_ID = process.env.APP_ID
+var states = require('./common/states').states
+var getLatestEpisode = require('./intentHandlers/getLatestEpisode')
+var playLatestEpisode = require('./intentHandlers/playLatestEpisode')
+var listPodcasts = require('./intentHandlers/listPodcasts')
+var playDirective = require('./common/directives').playDirective
 
 exports.handler = function (event, context, callback) {
   console.log(JSON.stringify(event))
+
+  var dynamoName = process.env.DYNAMO_ARN.split("/")[1]
+
   var alexa = Alexa.handler(event, context)
-  alexa.APP_ID = APP_ID
-  alexa.registerHandlers(handlers)
+  alexa.APP_ID = process.env.APP_ID
+  alexa.registerHandlers(commonHandlers, mainHandlers, gotPodcastHandlers)
+  alexa.dynamoDBTableName = dynamoName
   alexa.execute()
 }
 
-var handlers = {
+function getLaunchMessage(state) {
+  if (state === "") return `Welcome to Guardian Podcasts., I have regular podcasts about football, politics, science and books. You can also listen to in-depth reporting from the Guardian Long Read series. What would you like to hear?`
+  else return `Welcome back. Is there a particular podcast you want to play, or would you like a list of podcasts?`
 }
+
+var commonHandlers = {
+  'LaunchRequest': function() {
+
+    var msg = getLaunchMessage(this.handler.state)
+    this.handler.state = states.MAIN
+    this.emit(':ask', msg, 'How can I help?')
+  },
+
+  'GetPodcast': getLatestEpisode,
+
+  'PlayPodcast': playLatestEpisode,
+
+  'ListPodcasts': listPodcasts,
+
+  // TODO - handle these playback intents
+  'AMAZON.StopIntent': function() {
+    this.emit(':tell', 'STOPPED')
+  },
+
+  'PlaybackStarted': function() {
+    this.emit(':responseReady')
+  },
+
+  'PlaybackStopped': function() {
+    this.emit(':responseReady')
+  },
+
+  'PlaybackFinished': function() {
+    this.emit(':responseReady')
+  },
+
+  'AMAZON.PauseIntent': function() {
+    this.emit(':responseReady')
+  },
+
+  'AMAZON.ResumeIntent': function() {
+    this.emit(':responseReady')
+  },
+
+  'Unhandled': function() {
+    this.handler.state = states.MAIN
+    this.emit(':tell', `Sorry, I'm not sure what you're after.`)
+  }
+}
+
+var mainHandlers = Alexa.CreateStateHandler(states.MAIN, Object.assign({}, commonHandlers))
+
+// Users enter this state after we've told them about a particular podcast episode
+var gotPodcastHandlers = Alexa.CreateStateHandler(states.GOT_PODCAST,
+  Object.assign(
+    {
+      'AMAZON.YesIntent': function() {
+
+        var directive = playDirective(
+          this.attributes.episodeUrl,
+          this.attributes.episodeTitle,
+          0
+        )
+
+        this.handler.state = states.MAIN
+
+        this.context.succeed(directive)
+      },
+
+      'AMAZON.NoIntent': function() {
+        this.emit(':tell', 'OK')
+      }
+    },
+    commonHandlers
+  )
+)

--- a/src/intentHandlers/getLatestEpisode.js
+++ b/src/intentHandlers/getLatestEpisode.js
@@ -1,0 +1,26 @@
+var getEpisode = require('../common/getEpisode').getEpisode
+var states = require('../common/states').states
+
+/**
+ * Retrieve the details of the latest episode of the requested podcast, and ask the user if they'd like to hear it.
+ */
+module.exports = function() {
+  getEpisode(this.event.request.intent.slots)
+    .then((episodeDetails) => {
+
+      this.attributes.episodeUrl = episodeDetails.episodeUrl
+      this.attributes.episodeTitle = episodeDetails.episodeTitle
+      this.handler.state = states.GOT_PODCAST
+      this.emit(':saveState', true)
+
+      this.emit(
+        ':ask',
+        `Sure, the latest ${episodeDetails.podcastTitle} was ${episodeDetails.episodeTitle}; would you like me to play this now?`,
+        'How can I help?'
+      )
+    })
+    .catch(function (message) {
+      console.log(`Error getting podcast: ${message}`)
+      this.emit(':tell', message)
+    })
+}

--- a/src/intentHandlers/listPodcasts.js
+++ b/src/intentHandlers/listPodcasts.js
@@ -1,0 +1,9 @@
+
+module.exports = function() {
+  //TODO - send card
+  this.emit(
+    ':ask',
+    `I have regular podcasts about football, politics, science and books. You can also listen to in-depth reporting from the Guardian Long Read series. I have sent a full list to your Alexa app. What would you like to hear?`,
+    'How can I help?'
+  )
+}

--- a/src/intentHandlers/playLatestEpisode.js
+++ b/src/intentHandlers/playLatestEpisode.js
@@ -1,0 +1,24 @@
+var getEpisode = require('../common/getEpisode').getEpisode
+var playDirective = require('../common/directives').playDirective
+var states = require('../common/states').states
+
+/**
+ * Immediately start playing the latest episode of the requested podcast.
+ */
+module.exports = function() {
+  getEpisode(this.event.request.intent.slots)
+    .then((episodeDetails) => {
+
+      this.attributes.episodeUrl = episodeDetails.episodeUrl
+      this.attributes.episodeTitle = episodeDetails.episodeTitle
+      this.handler.state = states.MAIN
+      this.emit(':saveState', true)
+
+      var directive = playDirective(episodeDetails.episodeUrl, episodeDetails.episodeTitle, 0)
+      this.context.succeed(directive)
+    })
+    .catch(function (message) {
+      console.log(`Error getting podcast: ${message}`)
+      this.emit(':tell', message)
+    })
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,1 +1,17 @@
-const tap = require('tap')
+var tap = require('tap')
+
+var getEpisode = require('../src/common/getEpisode').getEpisode
+
+tap.test('Test get podcast', t => {
+  var slots = {
+    podcast: {
+      value: "football weekly"
+    }
+  }
+
+  return getEpisode(slots).then(function(result) {
+    t.equal(result.podcastTitle, 'Football Weekly')
+    t.equal(result.episodeTitle && result.episodeTitle !== "", true)
+    t.equal(result.episodeUrl && result.episodeUrl !== "", true)
+  })
+})


### PR DESCRIPTION
The sdk supports maintaining of state in dynamodb, so this skill now uses it. The old skill does dynamodb interactions manually.

- Different welcome messages for new vs existing users
- ListPodcasts intent
- PlayPodcast intent
- GetPodcast intent

TODO -
- Send a card with list of podcasts
- Support stop/resume
- Support more podcasts